### PR TITLE
Fixed ephemeral disk config error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ terraform.tfvars
 *.tfstate
 *.tfstate.backup
 *.tfvars
+*.tfplan
 
 **/.terraform.lock.hcl
 
@@ -67,3 +68,4 @@ test/go.sum
 
 TestRecord/
 **/TestRecord.md.tmp
+

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -20,7 +20,7 @@ module "vmss_linux" {
   admin_password = "P@ssw0rd1234"
 
   # The following variables are used for sizing the VMs.
-  vms_size = "Standard_D2d_v5"
+  vms_size = "Standard_D2S_v3"
 
   # The following variables are used for the VM subnet.
   subnet_id = azurerm_subnet.hub1-subnets.id

--- a/variables.tf
+++ b/variables.tf
@@ -145,7 +145,7 @@ variable "os_disk_caching" {
 variable "os_disk_size_gb" {
   description = "Size of the OS disk in GB."
   type        = number
-  default     = 2
+  default     = null
 }
 
 variable "os_ephemeral_disk_enabled" {
@@ -157,7 +157,7 @@ variable "os_ephemeral_disk_enabled" {
 variable "os_ephemeral_disk_placement" {
   description = "Placement for the local ephemeral disk. Value can be `CacheDisk` or `ResourceDisk`. See https://learn.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks."
   type        = string
-  default     = "ResourceDisk"
+  default     = "CacheDisk"
 }
 
 variable "os_disk_encryption_set_id" {


### PR DESCRIPTION
## Describe your changes
Realized that the problem wasn't the os disk size but rather a conflict with the `os_disk_size` setting and the `os_ephemeral_disk_placement` value.  Changed `os_ephemeral_disk_placement` to default to `CacheDisk` and now it's working.
 
## Issue number

Closing #17 

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

